### PR TITLE
Add GitHub Skills activity to activities list

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,6 +75,13 @@ activities = {
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
+    ,
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. First step in the GitHub Certifications program for college applications.",
+        "schedule": "Thursdays, 4:00 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    }
 }
 
 


### PR DESCRIPTION
This pull request adds the new "GitHub Skills" activity to the in-memory activities list, making it available for student registration as announced by the principal. Includes:
- Activity name: GitHub Skills
- Description: Learn practical coding and collaboration skills with GitHub. First step in the GitHub Certifications program for college applications.
- Schedule: Thursdays, 4:00 PM - 5:00 PM
- Max participants: 25

Closes #6.